### PR TITLE
Debugged the actual script and updated README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,26 +14,27 @@ certificates.
 
 If you self-host websites and you want to secure them with SSL,
 [LetsEncrypt.org] provides a free API for issuing and renewing SSL
-certificates, also offer a [Certbot] tool for auto-renewing
-certificates. It runs as a cron job, renews certificates only when
+certificates, along with a tool called [Certbot] for auto-renewing
+certificates. Certbot runs as a cron job, renews certificates when
 necessary, and updates your Apache / Nginx configs automatically.
-Unfortunately, [Certbot] grew fairly complicated and requires root
-privileges.
+However, certbot grew fairly complicated and requires root privileges.
 
-An alternative [acme-tiny] is a third-party command line tool that
-does only one thing and does it well: runs the ACME protocol and
-obtains a new SSL cerficiate for you. It does _not_ require root
-privileges, all of its configuration is completely on the command
-line, and it's under 200 lines long, so paranoid users can eyeball the
-code easily.
+An alternative tool, [acme-tiny], is a third-party command line tool
+that, in UNIX spirit, does one thing and does it well: runs the ACME
+protocol and obtains a new SSL cerficiate. It does _not_ require root
+privileges, and all of its configuration is straightforward and
+completely on the command line. The entire tool is under 200 lines
+long, so paranoid users can eyeball the code easily.
 
 However, [acme-tiny] is only one piece of the
 puzzle. Our tool, `acme-tiny-cron`, adds the following functionality:
 
 * Configuration for the domains, including (for each domain):
   - Production / staging setting
-  - Path to the ACME folder for domain validation
-  - Path to CSR (certificate signing request) file, etc.
+  - Path to the ACME challenge folder for domain validation
+  - Paths to files with CSR (certificate signing request), private
+    key, and the resulting certificate
+  - When to renew the certificate (how close to the expiration)
 * A script suitable to run in a cron job at high frequency (e.g. once
   a day or once an hour).
   - Certificates will only be renewed when they are approaching their
@@ -55,44 +56,118 @@ We recommend installing in a virtualenv, to isolate the dependencies
 from other global system installations:
 
 ```
-python -m venv ssl
+python3 -m venv ssl
 source ssl/bin/activate
 ./setup.py install
 ```
 
-### Allow `ssl-auto` user write access to the ACME folders
+### Create CSR requests for each of your domains
 
-E.g., if your websites are hosted at `/var/www/<domain>/`, and your
-server runs as `www-data` user:
+For example:
+
+```
+openssl req -newkey rsa:2048 -keyout /home/ssl-auto/certs/example.com/private.key \
+    -out /home/ssl-auto/certs/example.com/request.csr -nodes
+```
+
+For generating CSR without a prompt (non-interactively), use
+[-subj](https://www.shellhacks.com/create-csr-openssl-without-prompt-non-interactive/)
+or
+[-config](http://blog.endpoint.com/2014/10/openssl-csr-with-alternative-names-one.html)
+options.
+
+### Create a configuration file
+
+As an example, create a file `~/acme-tiny-cron.cfg` under the user
+`ssl-auto`. The file is in Google Protobuf v3 text format. Sample
+configuration for two domains:
+
+```proto
+// The schema for this config file is at
+// https://github.com/sergey-a-berezin/acme-tiny-cron/blob/master/acme_tiny_cron/protos/domains.proto
+
+staging_server:                   "https://acme-staging.api.letsencrypt.org/directory"
+production_server:              "https://acme-staging.api.letsencrypt.org/directory"
+log_path:                            "/var/log/acme/acme_tiny_cron.log"
+account_private_key_path: "/home/ssl-auto/private/my_letsencrypt_private.key"
+
+domain: {
+  name: "example.com"
+  name: "www.example.com"
+  mode: STAGING  // Testing the setup; cannot use this cert for real.
+  csr_path: "/home/ssl-auto/certs/example.com/request.csr"
+  private_key_path: "/home/ssl-auto/certs/example.com/private.key"
+  cert_path: "/home/ssl-auto/certs/example.com/cert.crt"
+  renew_days_before_expiration: 15  // Optional; default=30
+  acme_challenge_path: "/var/www/example.com/.well-known/acme-challenge"
+}
+
+domain: {
+  name: "my-real-domain.com"
+  name: "www.my-real-domain.com"
+  mode: PRODUCTION  // This is a real deal
+  csr_path: "/home/ssl-auto/certs/my-real-domain.com/request.csr"
+  private_key_path: "/home/ssl-auto/certs/my-real-domain.com/private.key"
+  cert_path: "/home/ssl-auto/certs/my-real-domain.com/cert.crt"
+  renew_days_before_expiration: 15  // Optional; default=30
+  acme_challenge_path: "/var/www/my-real-domain.com/.well-known/acme-challenge"
+}
+```
+
+### Setup file permissions
+
+#### Allow `acme_tiny_cron` write access to the ACME folders
+
+As an example, if your websites are hosted at `/var/www/<domain>/`,
+your server runs under `www-data` user, and `acme_tiny_cron` runs
+under `ssl-auto`:
 
 ```
 sudo mkdir /var/www/<domain>/.well-known   # do this for every domain
 sudo chown -R www-data /var/www/*/.well-known
 sudo chgrp -R ssl-auto /var/www/*/.well-known
-sudo chmod g+w -R ssl-auto /var/www/*/.well-known
+sudo chmod g+w -R /var/www/*/.well-known
 ```
 
-### Create CSR requests for each of your domains
+#### Allow web server read access to the certs and domain keys
 
-E.g.:
+With similar assumptions as above:
 
 ```
-openssl req -newkey rsa:2048 -keyout example.com-private.key \
-    -out example.com-request.csr -nodes
+sudo chgrp -R www-data /home/ssl-auto/certs
+sudo chmod g+r -R /home/ssl-auto/certs
 ```
 
-For generating CSR without a prompt (non-interactively),
-([use -subj](https://www.shellhacks.com/create-csr-openssl-without-prompt-non-interactive/)
-or
-[-config](http://blog.endpoint.com/2014/10/openssl-csr-with-alternative-names-one.html))
-options.
+#### Hide your account private key
 
-### Create a configuration file
+```
+chmod 700 -R /home/ssl-auto/private
+```
 
-<TODO: write this>
+### Configure your web server
 
-E.g. create a file `~/acme-tiny-cron.cfg`. The file is in Google
-Protobuf v3 text format.
+Point your server configs for the corresponding domains to look for
+the certs and domain private keys. For example, Apache2 configs may
+look like this:
+
+```
+<IfModule mod_ssl.c>
+  <VirtualHost *:443>
+        ServerName www.example.com
+        DocumentRoot /var/www/example.com
+        SSLEngine on
+        SSLCertificateFile      /home/ssl-auto/certs/example.com/cert.crt
+        SSLCertificateKeyFile   /home/ssl-auto/certs/example.com/private.key
+        SSLCACertificateFile    /etc/ssl/certs/letsencrypt_root_bundle.crt
+
+      # <other necessary configuration>
+
+  </VirtualHost>
+</IfModule>
+```
+
+You can also symlink to the `/home/ssl-auto/certs` folder from
+`/etc/ssl` and reference symlinks from the web server config.
 
 ### Setup a cron job
 

--- a/README.md
+++ b/README.md
@@ -86,9 +86,9 @@ configuration for two domains:
 // The schema for this config file is at
 // https://github.com/sergey-a-berezin/acme-tiny-cron/blob/master/acme_tiny_cron/protos/domains.proto
 
-staging_server:                   "https://acme-staging.api.letsencrypt.org/directory"
-production_server:              "https://acme-staging.api.letsencrypt.org/directory"
-log_path:                            "/var/log/acme/acme_tiny_cron.log"
+staging_server:           "https://acme-staging.api.letsencrypt.org"
+production_server:        "https://acme-v01.api.letsencrypt.org"
+log_path:                 "/var/log/acme/acme_tiny_cron.log"
 account_private_key_path: "/home/ssl-auto/private/my_letsencrypt_private.key"
 
 domain: {

--- a/acme_tiny_cron/__init__.py
+++ b/acme_tiny_cron/__init__.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from cron import run  # pragma: no cover
+from .cron import run

--- a/acme_tiny_cron/protos/domains.proto
+++ b/acme_tiny_cron/protos/domains.proto
@@ -21,9 +21,9 @@ package acme_tiny_cron;
 message Domains {
   // Domain configurations.
   repeated Domain domain = 1;
-  // Staging ACME server, e.g. "https://acme-staging.api.letsencrypt.org/directory"
+  // Staging ACME server, e.g. "https://acme-staging.api.letsencrypt.org"
   string staging_server = 2;
-  // Production ACME server, e.g. "https://acme-v01.api.letsencrypt.org/directory"
+  // Production ACME server, e.g. "https://acme-v01.api.letsencrypt.org"
   string production_server = 3;
   // Absolute path to log prefix, e.g. "/var/logs/acme/acme_tiny_cron.log"
   string log_path = 4;
@@ -40,7 +40,6 @@ message Domain {
     STAGING = 1;
   }
   // Common names, such as example.com, www.example.com.
-  // Not used, for information only.
   repeated string name = 1;
   // Absolute path to the CSR file, e.g.:
   // "/home/ssl-auto/certs/example.com/request.csr".  This file is

--- a/setup.py
+++ b/setup.py
@@ -27,8 +27,8 @@ INSTALL_REQUIRES = [
 def pip_install(package):
     p = subprocess.Popen(['pip', 'install', package], stdout=subprocess.PIPE)
     out, err = p.communicate()
-    for line in out.split('\n'):
-        print(line)
+    for line in out.splitlines():
+        print(line.decode('utf-8'))
 
 
 # For some reason, on Mac OS X `./setup.py install` wants to build


### PR DESCRIPTION
- Fixed the ACME server URL examples
- Made the script actually work both as an installed python package, and in tests
- Fixed logging messages in case when acme-tiny script fails