### PR TITLE
Made it work on Ubuntu

### DIFF
--- a/acme_tiny_cron/cron.py
+++ b/acme_tiny_cron/cron.py
@@ -24,7 +24,7 @@ import subprocess
 import sys
 
 import acme_tiny
-from google import protobuf
+from google.protobuf import text_format
 
 from .protos import domains_pb2
 
@@ -83,7 +83,7 @@ def need_renew(cert, days_to_renew, now):
 def read_config(config_path):
   config = domains_pb2.Domains()
   with open(config_path) as f:
-    protobuf.text_format.Merge(f.read(), config)
+    text_format.Merge(f.read(), config)
   return config
 
 

--- a/bootstrap
+++ b/bootstrap
@@ -62,7 +62,9 @@ function setup_env3 {
 	if [ -z "$PYTHON3" ]; then
 	    echo "  WARNING: Couldn't find Python 3 installation."
 	else
-	    "$PYTHON3" -m venv env3
+	    # Some Ubuntu systems have ensurepip disabled. Work around those.
+	    "$PYTHON3" -m venv env3 --without-pip --system-site-packages
+	    env3/bin/python -m pip install --upgrade pip
 	fi
     else
 	echo "Reusing the existing env3"


### PR DESCRIPTION
- protobuf.text_format is finicky in cron.py (but works from cron_test.py ??)
- python3 -m venv fails on Ubuntu, had to work around it.

Fixes #8.