### PR TITLE
Roll dependencies.

### DIFF
--- a/pip2.deps
+++ b/pip2.deps
@@ -1,5 +1,5 @@
-acme-tiny==2.0.0
-coverage==4.4.1
-cryptography==1.9
-protobuf==3.3.0
+acme-tiny==4.0.4
+coverage==4.5.1
+cryptography==2.2.2
 mock==2.0.0
+protobuf==3.5.2.post1

--- a/pip3.deps
+++ b/pip3.deps
@@ -1,4 +1,4 @@
-acme-tiny==2.0.0
-coverage==4.4.1
-cryptography==1.9
-protobuf==3.3.0
+acme-tiny==4.0.4
+coverage==4.5.1
+cryptography==2.2.2
+protobuf==3.5.2.post1


### PR DESCRIPTION
In particular, LetsEncrypt.org no longer works with acme-tiny 2.0.0.